### PR TITLE
Make AbstractControl and its children generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Register [FormBuilderFactory](https://github.com/Chacaroon/AutoForms/blob/master
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddAutoForms();
+	services.AddValidationProcessor();
 }
 ```
 
@@ -41,7 +42,7 @@ npm install @auto-forms/client
 
 ### Import AutoFormsModule to AppModule
 
-Add the `AutoFormsModule` to the `AppModule`, so you'll be able to inject [FormBuilderCllient](https://github.com/Chacaroon/AutoForms/blob/feature/readme/src/AutoForms.Client/projects/client/src/form-builder-client.ts).
+Add the `AutoFormsModule` to the `AppModule`, so you'll be able to inject [FormBuilderCllient](https://github.com/Chacaroon/AutoForms/blob/master/src/AutoForms.Client/projects/client/src/form-builder-client.ts).
 
 ```js
 import { AutoFormsModule } from '@auto-forms/client';

--- a/samples/AspNetCoreWithAngular/Startup.cs
+++ b/samples/AspNetCoreWithAngular/Startup.cs
@@ -27,7 +27,8 @@ public class Startup
                 .AllowAnyMethod()
                 .AllowAnyOrigin()));
 
-        services.AddAutoForms();
+        services.AddAutoForms()
+            .AddValidationProcessor();
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/AutoForms.Tests/ResolveFormByTypeTests.cs
+++ b/src/AutoForms.Tests/ResolveFormByTypeTests.cs
@@ -106,7 +106,7 @@ internal class ResolveFormByTypeTests
         var strategy = strategyResolver.Resolve(context);
 
         // Assert
-        var exception = Assert.Throws<CircularDependencyException>(() => strategy.Process(context, new()))!;
+        var exception = Assert.Throws<CircularDependencyException>(() => strategy.ProcessInternal(context, new()))!;
         Assert.AreEqual(expectedMessage, exception.Message);
     }
 

--- a/src/AutoForms.Tests/ResolveFormWithModelTests.cs
+++ b/src/AutoForms.Tests/ResolveFormWithModelTests.cs
@@ -34,11 +34,11 @@ internal class ResolveFormWithModelTests
 
         // Arrange
         var arrayPropertyControls = FindControl(formGroup, nameof(ComplexType.ArrayProperty));
-        var arrayPropertyValues = ((FormArray)arrayPropertyControls).Controls.Select(x => ((FormControl)x).Value);
+        var arrayPropertyValues = ((FormArray)arrayPropertyControls).Controls.Select(x => ((FormControl<object>)x).Value);
 
         Assert.NotNull(formGroup);
 
-        Assert.AreEqual("value", ((FormControl)FindControl(formGroup, nameof(ComplexType.StringProperty))).Value);
+        Assert.AreEqual("value", ((FormControl<object>)FindControl(formGroup, nameof(ComplexType.StringProperty))).Value);
         Assert.That(arrayPropertyValues, Is.EquivalentTo(new[] { 0 }));
     }
 
@@ -56,7 +56,7 @@ internal class ResolveFormWithModelTests
         Assert.NotNull(formArray);
 
         Assert.AreEqual(3, formArray.Controls.Count());
-        Assert.That(formArray.Controls.Select(x => ((FormControl)x).Value).Cast<int>(), Is.EquivalentTo(Enumerable.Range(0, 3)));
+        Assert.That(formArray.Controls.Select(x => ((FormControl<object>)x).Value).Cast<int>(), Is.EquivalentTo(Enumerable.Range(0, 3)));
     }
 
     [Test]
@@ -77,7 +77,7 @@ internal class ResolveFormWithModelTests
         var stringPropertyControls = formArray!.Controls
             .Select(x => FindControl(x as FormGroup, nameof(ComplexType.StringProperty)));
         var stringPropertyControlValues = stringPropertyControls
-            .Select(x => ((FormControl)x).Value);
+            .Select(x => ((FormControl<object>)x).Value);
 
         Assert.NotNull(formArray);
 
@@ -105,8 +105,8 @@ internal class ResolveFormWithModelTests
         Assert.AreEqual(ControlType.Group, formGroup.Type);
         Assert.AreEqual(2, formGroup.Controls.Count);
         Assert.That(formGroup.Controls.Keys, Is.EquivalentTo(new[] { "first", "second" }));
-        Assert.AreEqual((formGroup.Controls["first"] as FormControl)!.Value, 1);
-        Assert.AreEqual((formGroup.Controls["second"] as FormControl)!.Value, 2);
+        Assert.AreEqual((formGroup.Controls["first"] as FormControl<object>)!.Value, 1);
+        Assert.AreEqual((formGroup.Controls["second"] as FormControl<object>)!.Value, 2);
     }
 
     [Test]

--- a/src/AutoForms/Extensions/AutoFormsExtensions.cs
+++ b/src/AutoForms/Extensions/AutoFormsExtensions.cs
@@ -22,7 +22,7 @@ public static class AutoFormsExtensions
     /// <returns><see cref="IServiceCollection"/></returns>
     public static IServiceCollection AddAutoForms(this IServiceCollection serviceCollection)
     {
-        serviceCollection.AddScoped(services =>
+        serviceCollection.AddSingleton(services =>
             new StrategyResolver(services.GetRequiredService<IServiceProvider>()));
 
         serviceCollection.AddScoped(services =>

--- a/src/AutoForms/FormBuilder.cs
+++ b/src/AutoForms/FormBuilder.cs
@@ -45,6 +45,6 @@ public class FormBuilder
     /// </remarks>
     public AbstractControl Build()
     {
-        return _strategy.Process(new(_type) { Value = _value }, new());
+        return _strategy.ProcessInternal(new(_type) { Value = _value }, new());
     }
 }

--- a/src/AutoForms/Models/AbstractControl.cs
+++ b/src/AutoForms/Models/AbstractControl.cs
@@ -7,7 +7,7 @@ namespace AutoForms.Models;
 /// <summary>
 /// Base class from all types of controls.
 /// </summary>
-[KnownType(typeof(FormControl))]
+[KnownType(typeof(FormControl<>))]
 [KnownType(typeof(FormGroup))]
 [KnownType(typeof(FormArray))]
 [ExcludeFromCodeCoverage]

--- a/src/AutoForms/Models/AbstractControlCollectionBase.cs
+++ b/src/AutoForms/Models/AbstractControlCollectionBase.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace AutoForms.Models;
+
+/// <summary>
+/// Base type for abstract control that holds another controls.
+/// </summary>
+/// <typeparam name="T">The controls collection type</typeparam>
+[ExcludeFromCodeCoverage]
+public abstract class AbstractControlCollectionBase<T> : AbstractControl
+{
+    /// <summary>
+    /// Collection of the child controls.
+    /// </summary>
+    public T Controls { get; set; } = default!;
+}

--- a/src/AutoForms/Models/AbstractControlCollectionBase.cs
+++ b/src/AutoForms/Models/AbstractControlCollectionBase.cs
@@ -3,14 +3,14 @@
 namespace AutoForms.Models;
 
 /// <summary>
-/// Base type for abstract control that holds another controls.
+/// Base type for controls that holds another ones.
 /// </summary>
 /// <typeparam name="T">The controls collection type</typeparam>
 [ExcludeFromCodeCoverage]
 public abstract class AbstractControlCollectionBase<T> : AbstractControl
 {
     /// <summary>
-    /// Collection of the child controls.
+    /// The child controls.
     /// </summary>
     public T Controls { get; set; } = default!;
 }

--- a/src/AutoForms/Models/FormArray.cs
+++ b/src/AutoForms/Models/FormArray.cs
@@ -9,7 +9,7 @@ namespace AutoForms.Models;
 /// Represents control that holds collection of values.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class FormArray : AbstractControl
+public class FormArray : AbstractControlCollectionBase<IEnumerable<AbstractControl>>
 {
     /// <summary>
     /// Creates the <see cref="FormArray"/> instance
@@ -22,11 +22,6 @@ public class FormArray : AbstractControl
 
     /// <inheritdoc/>
     public override ControlType Type => ControlType.Array;
-
-    /// <summary>
-    /// Collection of the child controls.
-    /// </summary>
-    public IEnumerable<AbstractControl> Controls { get; set; }
 
     /// <summary>
     /// The structure of the child control.

--- a/src/AutoForms/Models/FormControl.cs
+++ b/src/AutoForms/Models/FormControl.cs
@@ -7,7 +7,7 @@ namespace AutoForms.Models;
 /// Represents control that holds indivisible value.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class FormControl : AbstractControl
+public class FormControl<T> : AbstractControl
 {
     /// <inheritdoc />
     public override ControlType Type => ControlType.Control;
@@ -15,5 +15,6 @@ public class FormControl : AbstractControl
     /// <summary>
     /// The FormControl's value
     /// </summary>
-    public object? Value { get; set; }
+    public T? Value { get; set; }
 }
+

--- a/src/AutoForms/Models/FormGroup.cs
+++ b/src/AutoForms/Models/FormGroup.cs
@@ -9,13 +9,8 @@ namespace AutoForms.Models;
 /// Represents control that holds object-like value.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class FormGroup : AbstractControl
+public class FormGroup : AbstractControlCollectionBase<Dictionary<string, AbstractControl>>
 {
     /// <inheritdoc />
     public override ControlType Type => ControlType.Group;
-
-    /// <summary>
-    /// Dictionary with the child controls.
-    /// </summary>
-    public Dictionary<string, AbstractControl> Controls { get; set; } = new();
 }

--- a/src/AutoForms/Processors/ValidationProcessor.cs
+++ b/src/AutoForms/Processors/ValidationProcessor.cs
@@ -28,21 +28,21 @@ internal class ValidationProcessor : BaseControlProcessor
         {
             RequiredAttribute requiredAttribute => new Models.Validator(ValidatorType.Required)
             {
-                Message = requiredAttribute.ErrorMessage
+                Message = requiredAttribute.ErrorMessage ?? "This field is required"
             },
             MinLengthAttribute minLengthAttribute => new Models.Validator(ValidatorType.MinLength)
             {
-                Message = minLengthAttribute.ErrorMessage,
+                Message = minLengthAttribute.ErrorMessage ?? $"Min length of this field is {minLengthAttribute.Length}",
                 Value = minLengthAttribute.Length
             },
             MaxLengthAttribute maxLengthAttribute => new Models.Validator(ValidatorType.MaxLength)
             {
-                Message = maxLengthAttribute.ErrorMessage,
+                Message = maxLengthAttribute.ErrorMessage ?? $"Max length of this field is {maxLengthAttribute.Length}",
                 Value = maxLengthAttribute
             },
             RegularExpressionAttribute regularExpressionAttribute => new Models.Validator(ValidatorType.RegularExpression)
             {
-                Message = regularExpressionAttribute.ErrorMessage,
+                Message = regularExpressionAttribute.ErrorMessage ?? "This field does not match the required pattern",
                 Value = regularExpressionAttribute.Pattern
             },
             _ => null

--- a/src/AutoForms/Strategies/BaseStrategy.cs
+++ b/src/AutoForms/Strategies/BaseStrategy.cs
@@ -25,7 +25,28 @@ internal abstract class BaseStrategy
 
     #region Helpers
 
-    protected void ProcessControl(AbstractControl control, FormBuilderContext context)
+    internal AbstractControl ProcessInternal(FormBuilderContext context, HashSet<Type> hashSet)
+    {
+        PreProcess(context, ref hashSet);
+
+        var control = Process(context, hashSet);
+
+        PostProcess(control, context);
+
+        return control;
+    }
+
+    private void PreProcess(FormBuilderContext context, ref HashSet<Type> hashSet)
+    {
+        CheckCircularDependency(ref hashSet, context.ModelType);
+    }
+
+    private void PostProcess(AbstractControl control, FormBuilderContext context)
+    {
+        ProcessControl(control, context);
+    }
+
+    private void ProcessControl(AbstractControl control, FormBuilderContext context)
     {
         foreach (var controlProcessor in _controlProcessors)
         {
@@ -33,7 +54,7 @@ internal abstract class BaseStrategy
         }
     }
 
-    protected void CheckCircularDependency(ref HashSet<Type> hashSet, Type type)
+    private void CheckCircularDependency(ref HashSet<Type> hashSet, Type type)
     {
         if (hashSet.Contains(type))
         {

--- a/src/AutoForms/Strategies/DictionaryFormGroupStrategy.cs
+++ b/src/AutoForms/Strategies/DictionaryFormGroupStrategy.cs
@@ -25,8 +25,6 @@ internal class DictionaryFormGroupStrategy : BaseStrategy
 
     internal override AbstractControl Process(FormBuilderContext context, HashSet<Type> hashSet)
     {
-        CheckCircularDependency(ref hashSet, context.ModelType);
-
         if (context.Value == null)
         {
             return new FormGroup();
@@ -44,7 +42,7 @@ internal class DictionaryFormGroupStrategy : BaseStrategy
             };
             return _strategyResolver
                 .Resolve(itemContext)
-                .Process(itemContext, hashSet);
+                .ProcessInternal(itemContext, hashSet);
         }
 
         var value = (IDictionary)context.Value!;
@@ -56,8 +54,6 @@ internal class DictionaryFormGroupStrategy : BaseStrategy
         {
             Controls = result
         };
-
-        ProcessControl(control, context);
 
         return control;
     }

--- a/src/AutoForms/Strategies/FormArrayStrategy.cs
+++ b/src/AutoForms/Strategies/FormArrayStrategy.cs
@@ -25,8 +25,6 @@ internal class FormArrayStrategy : BaseStrategy
 
     internal override AbstractControl Process(FormBuilderContext context, HashSet<Type> hashSet)
     {
-        CheckCircularDependency(ref hashSet, context.ModelType);
-
         var collectionItemType = GetCollectionItemType(context.ModelType);
 
         AbstractControl BuildControl(object? value = null)
@@ -38,15 +36,13 @@ internal class FormArrayStrategy : BaseStrategy
                 Value = value
             };
             return _strategyResolver.Resolve(collectionItemContext)
-                .Process(collectionItemContext, hashSet);
+                .ProcessInternal(collectionItemContext, hashSet);
         }
 
         var values = ((IEnumerable?)context.Value)?.Cast<object>() ?? Array.Empty<object>();
         var controls = values.Select(BuildControl);
 
         var formArray = new FormArray(controls, BuildControl());
-
-        ProcessControl(formArray, context);
 
         return formArray;
     }

--- a/src/AutoForms/Strategies/FormControlStrategy.cs
+++ b/src/AutoForms/Strategies/FormControlStrategy.cs
@@ -20,11 +20,7 @@ internal class FormControlStrategy : BaseStrategy
 
     internal override AbstractControl Process(FormBuilderContext context, HashSet<Type> hashSet)
     {
-        CheckCircularDependency(ref hashSet, context.ModelType);
-
-        var control = new FormControl { Value = context.Value };
-
-        ProcessControl(control, context);
+        var control = new FormControl<object> { Value = context.Value };
 
         return control;
     }

--- a/src/AutoForms/Strategies/FormGroupStrategy.cs
+++ b/src/AutoForms/Strategies/FormGroupStrategy.cs
@@ -26,8 +26,6 @@ internal class FormGroupStrategy : BaseStrategy
 
     internal override AbstractControl Process(FormBuilderContext context, HashSet<Type> hashSet)
     {
-        CheckCircularDependency(ref hashSet, context.ModelType);
-
         AbstractControl BuildControl(PropertyInfo propertyInfo, object? value)
         {
             var itemContext = context with
@@ -37,7 +35,7 @@ internal class FormGroupStrategy : BaseStrategy
                 Value = value,
             };
             return _strategyResolver.Resolve(itemContext)
-                .Process(itemContext, hashSet);
+                .ProcessInternal(itemContext, hashSet);
         }
 
         var properties = context.ModelType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
@@ -49,9 +47,7 @@ internal class FormGroupStrategy : BaseStrategy
         {
             Controls = controls
         };
-
-        ProcessControl(control, context);
-
+        
         return control;
     }
 


### PR DESCRIPTION
Make AbstractControl generic in order to generate strong typed models using Roslyn and Source Generator.
Refactor to extract repetitive logic from specific strategies in BaseStrategy.
Fix bugs.